### PR TITLE
Add pull_request trigger and improve Psalm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "phpunit/phpunit": "~8.0",
         "giorgiosironi/eris": "^0.11.0",
-        "vimeo/psalm": "~3.7.0"
+        "vimeo/psalm": "^3.7"
     },
     "suggest": {
         "innmind/operating-system": "To easily access to a machine control mechanism"


### PR DESCRIPTION
# Changed log
- Add `pull_request` trigger on GitHub action.
- To install latest Psalm version, it should define `^3.7` for `psalm` dependency.
- The GitHub action will be failed until issue #1 has been resolved.